### PR TITLE
Removing unicode characters from content.

### DIFF
--- a/zxllkada/Dump_Instagram_Information_ANY_ACCOUNT/SUPER_MODE/SuperLIB/login.py
+++ b/zxllkada/Dump_Instagram_Information_ANY_ACCOUNT/SUPER_MODE/SuperLIB/login.py
@@ -56,6 +56,7 @@ def ToTxt(Byline, Folder, As, Mode):
         os.makedirs(GlobalFolder+"/"+Folder+"/"+Mode)
 
     with open(GlobalFolder+"/"+Folder+"/"+Mode+"/"+As, "a+") as outfile :
+         Byline = Byline.encode('ascii', 'ignore').decode('ascii')
          outfile.write(Byline+"\n")
 
 ########################## [ APIS ] ##########################


### PR DESCRIPTION
This is necessary if there are any emojis in the biography of the Instagram account.
You can possibly limit the removal to just emoji because this code will remove non-ASCII characters (all other scripts other than English). But it solves my requirement.

GREAT JOB ON THIS REPOSITORY!!!! LOVE IT!!!!